### PR TITLE
fix: wait longer for cursor to move to the correct line in .d.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,13 @@ export function activate() {
         return
 
       // wait for e.selection to update (init 0)
-      await Promise.resolve()
+      const waitInterval = 5
+      const maxWait = 1000
+      for (let i = 0; i < maxWait; i += waitInterval) {
+        await new Promise(resolve => setTimeout(resolve, waitInterval))
+        if (e.selection.anchor.line !== 0)
+          break
+      }
 
       const line = e.document.lineAt(e.selection.anchor.line)
       const text = line.text


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This extension isn't working because it doesn't wait long enough for the cursor to move to the navigated-to line in the .d.ts file. This PR fixes that by polling for the cursor line to update, up to a max wait of 1 second.

### Linked Issues

Fixes #6

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
