### PR TITLE
fix: jump ends in shims.d.ts, fix #3

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,16 +10,7 @@
       "presentation": {
         "reveal": "never"
       },
-      "problemMatcher": [
-        {
-          "base": "$ts-webpack-watch",
-          "background": {
-            "activeOnStart": true,
-            "beginsPattern": "Build start",
-            "endsPattern": "Build success"
-          }
-        }
-      ],
+      "problemMatcher": [],
       "group": "build"
     }
   ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export function activate() {
 
       const line = e.document.lineAt(e.selection.anchor.line)
       const text = line.text
-      const regex = /:\s+typeof import\('([^']*)'?\)/
+      const regex = /:\s+typeof import\('([^']*)'\)/
       const match = text.match(regex)
       if (!match)
         return


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.sheincorp.cn/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The jump constantly ends up to `shims.d.ts`, the reason is triggering VSCode's "Go to definition" on `.vue` module with  some machine that not correctly configured "take over mode" by volar, will still goes to `shims.d.ts`.

From our investigation, it's quite common and I have reservations about coupling to volar's takeover mode, so I made a more straightforward change to ensure the availability of.vue components.

### Linked Issues

#3 

### Additional context

Nothing more, show you the code.
