### PR TITLE
fix: jump broken in Nuxt by double quote

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export function activate() {
 
       const line = e.document.lineAt(e.selection.anchor.line)
       const text = line.text
-      const regex = /:\s+typeof import\('([^']*)'\)/
+      const regex = /:\s+typeof import\(['"`]([^']*)['"`]\)/
       const match = text.match(regex)
       if (!match)
         return


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Supplement fix for https://github.com/antfu/vscode-goto-alias/pull/13 because I found that in Vitesse the generated `component.d.ts` is using single quote on path string while Nuxt is double, so I need to make this regexp more robust.

