### PR TITLE
fix: make plugin compatible with unplugin-auto-import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export function activate() {
       // 2. And we use VSCode built-in "Go to definition" command trigger any
       //    other condition's jump
       else {
-        const importNameStart = match.index! + match[0].length - match[1].length - 1
+        const importNameStart = match.index! + match[0].length + 2
         e.selection = new Selection(
           new Position(
             e.selection.anchor.line,
@@ -76,7 +76,7 @@ export function activate() {
           ),
           new Position(
             e.selection.anchor.line,
-            importNameStart + match[1].length,
+            importNameStart,
           ),
         )
         triggerDoc = undefined


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This small tweak makes the plugin work with definitions generated by `unplugin-auto-import`, `auto-imports.d.ts`. It places the cursor within square brackets and quotes after import() to make VSCode navigate to the correct line in the targeted file, instead of just to the file. The behavior with Vue component import definitions (`components.d.ts`) remains unchanged.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
