### PR TITLE
Close .d.ts file by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "properties": {
         "gotoAlias.closeDts": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Close the .d.ts file after jumping to the definition"
         }
       }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I think it's better that by default it closes components.d.ts

### Linked Issues
Resolving this [issue](https://github.com/antfu/vscode-goto-alias/issues/19). 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
