### PR TITLE
chore: hint about value `gotoAndPeek` of VSCode setting `editor.gotoLocation.multipleDefinitions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Go to Definition following alias redirections.
 
 Install this extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=antfu.goto-alias).
 
-Set `editor.gotoLocation.multipleDefinitions` to `goto` in your VS Code settings for the best experience.
+Set `editor.gotoLocation.multipleDefinitions` to `goto` (directly jump into the primary result in definitions) or `gotoAndPeek` (also open the peek view to allow switch between definitions) in your VS Code settings for the best experience.
 
 ```json
 {
-  "editor.gotoLocation.multipleDefinitions": "goto"
+  "editor.gotoLocation.multipleDefinitions": "gotoAndPeek"
 }
 ```
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->
Many types in Nuxt are defined multiple times across dependencies and `*.ts` in generated `.nuxt/types`, using `editor.gotoLocation.multipleDefinitions: goto` might misleading user that many types only have one definition.

### Linked Issues

https://github.com/microsoft/vscode/issues/104824

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
